### PR TITLE
Load js file only on search page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -243,10 +243,12 @@
             }
         });
     </script>
+    {% if current == "search" %}
     <script src="https://files.stork-search.net/releases/v1.4.0/stork.js"></script>
     <script>
         stork.register("sitesearch", "{{ SITEURL }}/search-index.st")
     </script>
+    {% endif %}
 </body>
 
 </html>


### PR DESCRIPTION
To avoid `Uncaught StorkError: Could not register search box "sitesearch": input element not found. Make sure an element matches the query selector input[data-stork="sitesearch"]` (like on your website https://aleylara.github.io/Papyrus/), we need to load this code only on search page.