### PR TITLE
Remove leading space in link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -205,7 +205,7 @@
         <div class="px-4">
             <span>{% if COPYRIGHT %}{{ COPYRIGHT }}&nbsp;&#8226;&nbsp;{% endif %}</span>Powered by
             <a class="underline" href="https://getpelican.com/">Pelican</a>&nbsp;&
-            <a class="underline" href="https://github.com/aleylara/Papyrus">&nbsp;Papyrus</a>
+            <a class="underline" href="https://github.com/aleylara/Papyrus">Papyrus</a>
         </div>
     </footer>
 


### PR DESCRIPTION
There was a leading space in the link which looked a little wierd so from this:

<img width="198" alt="Screenshot 2023-01-31 at 2 28 19 PM" src="https://user-images.githubusercontent.com/74699/215898440-13ec6755-1f58-44d9-869c-17635541203f.png">

To this:

<img width="133" alt="Screenshot 2023-01-31 at 2 28 44 PM" src="https://user-images.githubusercontent.com/74699/215898453-5b89cd24-5895-4f5d-9be2-170bef95f2c9.png">
